### PR TITLE
added PARTFILE_DIR support

### DIFF
--- a/examples/qio-convert-mesh.c
+++ b/examples/qio-convert-mesh.c
@@ -141,6 +141,7 @@ int qio_mesh_convert(QIO_Filesystem *fs, QIO_Mesh_Topology *mesh,
     {
       printf("Converting %s from SINGLEFILE to PARTFILE\n",filename);
       status = QIO_single_to_part(filename, fs, mpp_layout);
+      status = QIO_single_to_part(filename, fs, mpp_layout, QIO_PARTFILE);
     }
   else if(part_to_single == 1)
     {

--- a/include/dml.h
+++ b/include/dml.h
@@ -11,6 +11,7 @@
 #define DML_SINGLEFILE 0
 #define DML_MULTIFILE  1
 #define DML_PARTFILE   2
+#define DML_PARTFILE_DIR    3
 
 /* Data distribution */
 #define DML_FIELD      0

--- a/include/qio.h
+++ b/include/qio.h
@@ -12,6 +12,7 @@
 #define QIO_SINGLEFILE DML_SINGLEFILE 
 #define QIO_MULTIFILE  DML_MULTIFILE  
 #define QIO_PARTFILE   DML_PARTFILE
+#define QIO_PARTFILE_DIR    DML_PARTFILE_DIR
 
 #define QIO_FIELD      DML_FIELD
 #define QIO_GLOBAL     DML_GLOBAL
@@ -179,7 +180,7 @@ int QIO_verbosity(void);
 
 /* HostAPI */
 int QIO_single_to_part( const char filename[], QIO_Filesystem *fs,
-			QIO_Layout *layout);
+			QIO_Layout *layout, int volfmt);
 int QIO_part_to_single( const char filename[], int ildgstyle, 
 			QIO_String *ildgLFN, 
 			QIO_Filesystem *fs, QIO_Layout *layout);

--- a/lib/dml/DML_utils.c
+++ b/lib/dml/DML_utils.c
@@ -232,8 +232,9 @@ DML_SiteList *DML_init_sitelist(int volfmt, int serpar, DML_Layout *layout){
     sites->number_of_io_sites = layout->sites_on_node;
   }
 
-  else if(volfmt == DML_PARTFILE || 
-	  (volfmt == DML_SINGLEFILE && serpar == DML_PARALLEL)){
+  else if(volfmt == DML_PARTFILE 
+          || volfmt == DML_PARTFILE_DIR 
+          || (volfmt == DML_SINGLEFILE && serpar == DML_PARALLEL)){
     /* Partitioned I/O requires a separate sitelist for each I/O
        partition.  Parallel I/O uses a sitelist to determine which
        sites to read or write. */
@@ -469,8 +470,9 @@ int DML_fill_sitelist(DML_SiteList *sites, int volfmt, int serpar,
   /* Multifile format requires a sitelist */
     return DML_fill_multifile_sitelist(layout,sites);
   }
-  else if(volfmt == DML_PARTFILE || 
-	  (volfmt == DML_SINGLEFILE && serpar == DML_PARALLEL)){
+  else if(volfmt == DML_PARTFILE 
+          || volfmt == DML_PARTFILE_DIR
+          || (volfmt == DML_SINGLEFILE && serpar == DML_PARALLEL)){
     /* Partitioned I/O requires a sitelist on the I/O node */
     /* Singlefile parallel I/O requires the same sitelist as partfile
        to determine which sites to write/read */
@@ -1251,7 +1253,7 @@ int DML_my_ionode(int volfmt, int serpar, DML_Layout *layout){
   else if(volfmt == DML_MULTIFILE){
     return layout->this_node;
   }
-  else if(volfmt == DML_PARTFILE){
+  else if(volfmt == DML_PARTFILE || volfmt == DML_PARTFILE_DIR){
     return layout->ionode(layout->this_node);
   }
   else {
@@ -1611,7 +1613,7 @@ static void DML_flush_tbuf_to_outbuf(size_t size,
    of nodes containing sites belonging to any single I/O node are
    disjoint from the corresponding set for any other I/O node.  This
    algorithm is intended for SINGLEFILE/SERIAL, MULTIFILE, and
-   PARTFILE modes. */
+   PARTFILE/PARTFILE_DIR modes. */
 
 uint64_t DML_partition_out(LRL_RecordWriter *lrl_record_out, 
 	   void (*get)(char *buf, size_t index, int count, void *arg),
@@ -1657,7 +1659,7 @@ uint64_t DML_partition_out(LRL_RecordWriter *lrl_record_out,
 #if 0
   /* For parallel I/O we don't try to buffer for messaging.  When each
      node can do I/O the data being written is local.  If we start
-     doing PARTFILE parallel I/O we may want to buffer. */
+     doing PARTFILE/PARTFILE_DIR parallel I/O we may want to buffer. */
   if(serpar == DML_PARALLEL){
     max_buf_sites = 1;
     max_tbuf_sites = 1;
@@ -1847,7 +1849,7 @@ uint64_t DML_partition_out(LRL_RecordWriter *lrl_record_out,
    of nodes containing sites belonging to any single I/O node are
    disjoint from the corresponding set for any other I/O node.  This
    algorithm is intended for SINGLEFILE/SERIAL, MULTIFILE, and
-   PARTFILE modes. */
+   PARTFILE/PARTFILE_DIR modes. */
 
 /* This is the old algorithm that sent only one site's worth at a time */
 
@@ -2509,7 +2511,7 @@ uint64_t DML_partition_close_in(DML_RecordReader *dml_record_in)
    of nodes containing sites belonging to any single I/O node are
    disjoint from the corresponding set for any other I/O node.  This
    algorithm is intended for SINGLEFILE/SERIAL, MULTIFILE, and
-   PARTFILE modes. */
+   PARTFILE/PARTFILE_DIR modes. */
 uint64_t
 DML_partition_in(LRL_RecordReader *lrl_record_in, 
 		 void (*put)(char *buf, size_t index, int count, void *arg),

--- a/lib/lrl/LRL_main.c
+++ b/lib/lrl/LRL_main.c
@@ -143,6 +143,7 @@ LRL_RecordReader *LRL_open_read_record(LRL_FileReader *fr,
 	     lime_status);
       *status = LRL_ERR_READ;
     }
+    free(rr);
     return NULL;
   }
 

--- a/lib/qio/QIO_info_private.c
+++ b/lib/qio/QIO_info_private.c
@@ -444,7 +444,8 @@ int QIO_insert_volfmt(QIO_FileInfo *file_info, int volfmt){
   file_info->volfmt.occur = 0;
   if(volfmt!=QIO_SINGLEFILE && 
      volfmt!=QIO_MULTIFILE &&
-     volfmt!=QIO_PARTFILE){
+     volfmt!=QIO_PARTFILE &&
+     volfmt!=QIO_PARTFILE_DIR){
     printf("QIO_insert_volfmt: Bad volfmt parameter %d\n",volfmt);
     return QIO_BAD_ARG;
   }

--- a/lib/qio/QIO_read_record_info.c
+++ b/lib/qio/QIO_read_record_info.c
@@ -65,9 +65,11 @@ int QIO_read_private_record_info(QIO_Reader *in, QIO_RecordInfo *record_info)
 	xml_record_private = QIO_string_create();
 	
 	/* Read private record XML */
-	if((status=QIO_read_string(in, xml_record_private, &lime_type ))
-	   != QIO_SUCCESS)return status;
-	
+	if((status=QIO_read_string(in, xml_record_private, &lime_type )) 
+	        != QIO_SUCCESS) {
+          QIO_string_destroy(xml_record_private);
+          return status;
+        }	
 	if(QIO_verbosity() >= QIO_VERB_DEBUG){
 	  printf("%s(%d): private XML = \"%s\"\n",myname,this_node,
 		 QIO_string_ptr(xml_record_private));
@@ -75,8 +77,10 @@ int QIO_read_private_record_info(QIO_Reader *in, QIO_RecordInfo *record_info)
 	
 	/* Decode the private record XML */
 	status = QIO_decode_record_info(&(in->record_info), xml_record_private);
-	if(status != 0)return QIO_ERR_PRIVATE_REC_INFO;
-
+	if(status != 0) { 
+          QIO_string_destroy(xml_record_private);
+          return QIO_ERR_PRIVATE_REC_INFO;
+        }
 	/* Free storage */
 	QIO_string_destroy(xml_record_private);
       }


### PR DESCRIPTION
similar to partfile, but every file is written to a separate directory 'volNNNN'
I.e. when opening a file 

> DIR/FILE.lime

for writing, the following files will be created along with directories:

> DIR/vol0000/FILE.lime
> DIR/vol0001/FILE.lime
> ....

When reading, format auto-detect will first try to open a SINGLEFILE, then PARTFILE, then PARTFILE_DIR
