### PR TITLE
Update submodule, a few warning fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "other_libs/c-lime"]
 	path = other_libs/c-lime
-	url = https://github.com/usqcd-software/c-lime
-	branch = master
+        url = ../c-lime.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "other_libs/c-lime"]
 	path = other_libs/c-lime
-	url = ../c-lime.git
+	url = https://github.com/usqcd-software/c-lime
+	branch = master

--- a/lib/qio/QIO_host_utils.c
+++ b/lib/qio/QIO_host_utils.c
@@ -109,10 +109,10 @@ int QIO_ionode_node_number(const int coords[]){
 }
 
 /* Map coordinates to fake node index */
-int QIO_ionode_node_index(const int coords[]){
+size_t QIO_ionode_node_index(const int coords[]){
 
   /* The actual node that will receive these coordinates */
-  int node = QIO_mpp_layout.node_number(coords);
+  size_t node = QIO_mpp_layout.node_number(coords);
 
   /* The fake node_index offset for this node */
   size_t offset = QIO_node_index_offset[node];
@@ -391,8 +391,8 @@ int QIO_scalar_node_number(const int coords[]){
 /* This is not the standard hypercube layout for a scalar
    machine, but it is fine for file conversion */
 /* CAUTION: conversion from DML_SiteRank type to int */
-int QIO_scalar_node_index(const int coords[]){
-  int index = DML_lex_rank(coords, QIO_mpp_layout.latdim, QIO_mpp_layout.latsize);
+size_t QIO_scalar_node_index(const int coords[]){
+  size_t index = DML_lex_rank(coords, QIO_mpp_layout.latdim, QIO_mpp_layout.latsize);
   return index;
 }
 


### PR DESCRIPTION
This PR updates the c-lime submodule to match the current master version of `c-lime`. Without this fix `git clone --recursive` won't work, which blocks formally adding QIO largefile support for QUDA.