### PR TITLE
Fix warnings

### DIFF
--- a/examples/layout_hyper.c
+++ b/examples/layout_hyper.c
@@ -56,6 +56,9 @@ static int *mcoord;
 #define MAXPRIMES (sizeof(prime)/sizeof(int))
 
 static void setup_qmp_grid(int len[], int nd, int numnodes){
+  _QIO_UNUSED_PARAM(nd);
+  _QIO_UNUSED_PARAM(numnodes);
+
   int ndim2, i;
   const int *nsquares2;
 
@@ -77,6 +80,7 @@ static void setup_qmp_grid(int len[], int nd, int numnodes){
 
 void setup_hyper_prime(int len[], int nd, int numnodes)
 {
+  _QIO_UNUSED_PARAM(nd);
   int i, j, k, n;
 
   /* Figure out dimensions of rectangle */
@@ -244,5 +248,6 @@ void get_coords(int x[], int node, int index)
 
 /* The number of sites on the specified node */
 int num_sites(int node){
+  _QIO_UNUSED_PARAM(node);
   return sites_on_node;
 }

--- a/examples/layout_hyper_mesh.c
+++ b/examples/layout_hyper_mesh.c
@@ -18,7 +18,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-
+#include <qio.h>
 static int sites_on_node;
 static int *squaresize;   /* dimensions of hypercubes */
 static int *nsquares;     /* number of hypercubes in each direction */
@@ -183,5 +183,6 @@ get_coords(int x[], int node, int index)
 
 /* The number of sites on the specified node */
 int num_sites(int node){
+  _QIO_UNUSED_PARAM(node);
   return sites_on_node;
 }

--- a/examples/qio-convert-mesh-ppfs.c
+++ b/examples/qio-convert-mesh-ppfs.c
@@ -205,7 +205,8 @@ static QIO_Filesystem *create_multi_ppfs(void){
     if(j == 1) fs->node_path[i][0] = '\0';
     /* Otherwise, copy the path to the table */
     else{
-      strncpy(fs->node_path[i], path, PATHLENGTH);
+      /*      strncpy(fs->node_path[i], path, PATHLENGTH); */
+      sprintf(fs->node_path[i],"%s",path);
       fs->node_path[i][PATHLENGTH] = '\0';
     }
 

--- a/examples/qio-test-util.c
+++ b/examples/qio-test-util.c
@@ -170,6 +170,8 @@ void vget_R(char *buf, size_t index, int count, void *qfin)
 /* Internal factory function for array of real global data */
 void vput_r(char *buf, size_t index, int count, void *qfin)
 {
+  _QIO_UNUSED_PARAM(index);
+
   float *array = (float *)qfin;
   float *src = (float *)buf;
   int i;
@@ -183,6 +185,8 @@ void vput_r(char *buf, size_t index, int count, void *qfin)
 /* Internal factory function for array of real global data */
 void vget_r(char *buf, size_t index, int count, void *qfin)
 {
+  _QIO_UNUSED_PARAM(index);
+
   float *array = (float *)qfin;
   float *dest = (float *)buf;
   int i;

--- a/include/qio.h
+++ b/include/qio.h
@@ -345,4 +345,8 @@ int QIO_write_field(QIO_Writer *out, int msg_begin, int msg_end,
 }
 #endif
 
+#ifndef _QIO_UNUSED_PARAM
+#define _QIO_UNUSED_PARAM(p)  (void)(p)
+#endif
+
 #endif /* QIO_H */

--- a/include/qio.h
+++ b/include/qio.h
@@ -75,6 +75,7 @@
 #define QIO_LIMETYPE_ILDG_BINARY_DATA   "ildg-binary-data"
 #define QIO_LIMETYPE_ILDG_DATA_LFN      "ildg-data-lfn"
 
+#define QIO_MAX_FILENAME_LENGTH   512
 #ifdef __cplusplus
 extern "C"
 {

--- a/include/qio_string.h
+++ b/include/qio_string.h
@@ -21,7 +21,7 @@ void QIO_string_set(QIO_String *qs, const char *const string);
 size_t QIO_string_length(const QIO_String *const qs);
 char * QIO_string_ptr(QIO_String *qs);
 void QIO_string_copy(QIO_String *dest, QIO_String *src);
-void QIO_string_realloc(QIO_String *qs, int length);
+void QIO_string_realloc(QIO_String *qs, size_t length);
 void QIO_string_append(QIO_String *qs, const char *const string);
 
 #ifdef __cplusplus

--- a/include/qioxml_private.h
+++ b/include/qioxml_private.h
@@ -266,7 +266,7 @@ char *QIO_get_datatype(QIO_RecordInfo *record_info);
 char *QIO_get_precision(QIO_RecordInfo *record_info);
 int QIO_get_colors(QIO_RecordInfo *record_info);
 int QIO_get_spins(QIO_RecordInfo *record_info);
-int QIO_get_typesize(QIO_RecordInfo *record_info);
+size_t QIO_get_typesize(QIO_RecordInfo *record_info);
 int QIO_get_datacount(QIO_RecordInfo *record_info);
 
 void QIO_set_recordtype(QIO_RecordInfo *record_info, int recordtype);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -37,6 +37,10 @@ else()
 endif()
 
 
+set_target_properties(qio PROPERTIES 
+		C_STANDARD 99
+		C_EXTENSIONS OFF)
+
 target_link_libraries(qio PUBLIC CLime::lime)
 if(QIO_ENABLE_PARALLEL_BUILD)
   target_link_libraries(qio PUBLIC QMP::qmp)

--- a/lib/dml/DML_route.c
+++ b/lib/dml/DML_route.c
@@ -40,7 +40,7 @@ QMP_status_t DML_grid_route(void* buffer, size_t count,
   void *recvbuf;                 
 
   int i,j;                   /* Loop Counters. Use for directions too */
-  int me;                    /* My node */
+  size_t me;                    /* My node */
 
   int n_hops;                      /* Number of hops */
   int  direction_sign;       /* Direction of hops */

--- a/lib/dml/DML_utils.c
+++ b/lib/dml/DML_utils.c
@@ -121,6 +121,7 @@ char *DML_allocate_msg(size_t size, char *myname, int this_node){
 /*------------------------------------------------------------------*/
 /* Accessor: Pointer to datum member of msg */
 char *DML_msg_datum(char *msg, size_t size){
+  _QIO_UNUSED_PARAM(size);
   return msg;
 }
 
@@ -406,7 +407,7 @@ int DML_fill_partition_sitelist(DML_Layout *layout, DML_SiteList *sites){
   int latdim = layout->latdim;
   int *latsize = layout->latsize;
   int node;
-  int node_sites;
+  size_t node_sites;
   int this_node = layout->this_node;
   int my_io_node = layout->ionode(this_node);
   int number_of_nodes = layout->number_of_nodes;
@@ -493,6 +494,7 @@ int DML_fill_sitelist(DML_SiteList *sites, int volfmt, int serpar,
 int DML_read_sitelist(DML_SiteList *sites, LRL_FileReader *lrl_file_in,
 		      int volfmt, DML_Layout *layout,
 		      LIME_type *lime_type){
+  _QIO_UNUSED_PARAM(volfmt);
   uint64_t check, announced_rec_size;
   int this_node = layout->this_node;
   LRL_RecordReader *lrl_record_in;
@@ -2023,6 +2025,7 @@ size_t DML_global_out(LRL_RecordWriter *lrl_record_out,
            DML_Layout *layout, int volfmt, 
 	   DML_Checksum *checksum)
 {
+  _QIO_UNUSED_PARAM(volfmt);
   char *buf;
   int this_node = layout->this_node;
   size_t nbytes = 0;
@@ -2162,6 +2165,7 @@ uint64_t DML_multifile_in(LRL_RecordReader *lrl_record_in,
 	     int count, size_t size, int word_size, void *arg, 
 	     DML_Layout *layout, DML_Checksum *checksum)
 {
+  _QIO_UNUSED_PARAM(sitelist);
   size_t buf_sites, buf_extract, max_buf_sites;
   size_t isite, max_send_sites;
   uint64_t nbytes = 0;
@@ -2468,7 +2472,8 @@ int DML_partition_allsitedata_in(DML_RecordReader *dml_record_in,
 	  DML_Layout *layout, DML_SiteList *sites, int volfmt,
 	  DML_Checksum *checksum)
 {
-
+  _QIO_UNUSED_PARAM(volfmt);
+  _QIO_UNUSED_PARAM(checksum);
   DML_SiteRank rcv_coords;
 
   if(DML_init_subset_site_loop(&rcv_coords, sites) == 0)
@@ -2570,7 +2575,7 @@ DML_partition_in(LRL_RecordReader *lrl_record_in,
   int *node_index = (int*)DML_allocate_buf(sizeof(*node_index),&max_buf_sites);
   int notdone = 1;
   while(notdone) {
-    int k = 0;
+    size_t k = 0;
     do { // get list of file contiguous sites
       /* The subset_rank locates the datum for rcv_coords in the
 	 record our I/O partition is reading */
@@ -2605,7 +2610,7 @@ DML_partition_in(LRL_RecordReader *lrl_record_in,
     }
     nextrank = firstrank + k;
 
-    for(int i=0; i<k; i++) {
+    for(size_t i=0; i<k; i++) {
       buf = inbuf + i*size;
       /* Send result to destination node. Avoid I/O node sending to itself. */
       if (dest_node[i] != my_io_node) {
@@ -2650,6 +2655,7 @@ size_t DML_global_in(LRL_RecordReader *lrl_record_in,
           DML_Layout* layout, int volfmt, int broadcast_globaldata,
 	  DML_Checksum *checksum)
 {
+  _QIO_UNUSED_PARAM(volfmt);
   char *buf;
   int this_node = layout->this_node;
   size_t nbytes = 0;

--- a/lib/qio/QIO_host_file_conversion.c
+++ b/lib/qio/QIO_host_file_conversion.c
@@ -142,6 +142,9 @@ int QIO_host_master_io_node( void )
    to the field */
 void QIO_scalar_put( char *s1 , size_t scalar_index, int count, void *s2 )
 {
+  _QIO_UNUSED_PARAM(scalar_index);
+  _QIO_UNUSED_PARAM(count);
+
   get_put_arg *arg = (get_put_arg *)s2;
   s_field *field = arg->field;
   size_t datum_size = field->datum_size;
@@ -158,6 +161,9 @@ void QIO_scalar_put( char *s1 , size_t scalar_index, int count, void *s2 )
 void QIO_scalar_put_global( char *s1 , size_t scalar_index, 
 			    int count, void *s2 )
 {
+  _QIO_UNUSED_PARAM(scalar_index);
+  _QIO_UNUSED_PARAM(count);
+
   get_put_arg *arg = (get_put_arg *)s2;
   s_field *field = arg->field;
 
@@ -206,6 +212,9 @@ void QIO_scalar_get( char *s1, size_t ionode_index, int count, void *s2 )
 void QIO_scalar_get_global( char *s1 , size_t ionode_index, 
 			    int count, void *s2 )
 {
+  _QIO_UNUSED_PARAM(ionode_index);
+  _QIO_UNUSED_PARAM(count);
+
   get_put_arg *arg = (get_put_arg *)s2;
   s_field *field     = arg->field;
   int node           = arg->node;
@@ -220,6 +229,9 @@ void QIO_scalar_get_global( char *s1 , size_t ionode_index,
 
 void QIO_part_get( char *s1 , size_t scalar_index, int count, void *s2 )
 {
+  _QIO_UNUSED_PARAM(scalar_index);
+  _QIO_UNUSED_PARAM(count);
+
   get_put_arg *arg = (get_put_arg *)s2;
   s_field *field = arg->field;
   size_t datum_size = field->datum_size;
@@ -269,6 +281,8 @@ void QIO_part_put( char *s1 , size_t ionode_index, int count, void *s2 )
    to the field */
 void QIO_part_put_global( char *s1 , size_t ionode_index, int count, void *s2 )
 {
+  _QIO_UNUSED_PARAM(ionode_index);
+  _QIO_UNUSED_PARAM(count);
   get_put_arg *arg = (get_put_arg *)s2;
   s_field *field = arg->field;
   int node = arg->node;

--- a/lib/qio/QIO_host_file_conversion.c
+++ b/lib/qio/QIO_host_file_conversion.c
@@ -309,30 +309,30 @@ char *QIO_set_filepath(QIO_Filesystem *fs,
 		  const char * const filename, int node)
 {
   char *path, *newfilename=NULL;
-  int fnlength = strlen(filename);
-  int drlength;
+  size_t fnlength = strlen(filename);
+  size_t drlength;
   
-  if (fs->type == QIO_MULTI_PATH)
-    {
-      path = fs->node_path[node];
-      drlength = strlen(path);
-      newfilename = (char *) malloc(fnlength+drlength+2);
-      if(!newfilename){
-	printf("QIO_set_filepath: Can't malloc newfilename\n");
-	return NULL;
-      }
-      newfilename[0] = '\0';
-      if(drlength > 0){
-	strncpy(newfilename, path, drlength+1);
-	strncat(newfilename, "/", 2);
-      }
-      strncat(newfilename, filename, fnlength+1);
+  if (fs->type == QIO_MULTI_PATH) {
+    path = fs->node_path[node];
+    drlength = strlen(path);
+    newfilename = (char *) malloc(fnlength+drlength+2);
+    if(!newfilename){
+      printf("QIO_set_filepath: Can't malloc newfilename\n");
+      return NULL;
     }
-  else if (fs->type == QIO_SINGLE_PATH)
-    {
-      newfilename = (char *) malloc(fnlength+1);
-      strncpy(newfilename,filename,fnlength+1);
+    newfilename[0] = '\0';
+    if(drlength > 0){
+      sprintf(newfilename, "%s/%s",path,filename);
     }
+  }
+  else if (fs->type == QIO_SINGLE_PATH) {
+    newfilename = (char *) malloc(fnlength+1);
+    if(!newfilename){
+      printf("QIO_set_filepath: Can't malloc newfilename\n");
+      return NULL;
+    }
+    sprintf(newfilename,"%s", filename);
+  }
   
   return newfilename;
 }
@@ -1080,7 +1080,8 @@ int QIO_part_to_single( const char filename[], int ildgstyle,
 
 	  /* Copy LIME type */
 	  lime_type_out = (char *)malloc(strlen(lime_type_in)+1);
-	  strncpy(lime_type_out,lime_type_in,strlen(lime_type_in)+1);
+	  if( lime_type_out == NULL ) return QIO_BAD_ARG;
+	  sprintf(lime_type_out,"%s",lime_type_in);
 
 	  /* Now close the master ionode file.  We will reread the
 	     private and user file xml later */

--- a/lib/qio/QIO_host_utils.c
+++ b/lib/qio/QIO_host_utils.c
@@ -382,6 +382,7 @@ void QIO_delete_ionode_layout(QIO_Layout *layout){
 /* The fake scalar layout structure */
 /* All sites are stored in lexicographic order on the host, "node 0" */
 int QIO_scalar_node_number(const int coords[]){
+  _QIO_UNUSED_PARAM(coords);
   return 0;
 }
 
@@ -395,12 +396,14 @@ int QIO_scalar_node_index(const int coords[]){
 }
 
 void QIO_scalar_get_coords(int coords[], int node, int index){
+  _QIO_UNUSED_PARAM(node);
   int latdim = QIO_mpp_layout.latdim;
   int *latsize = QIO_mpp_layout.latsize;
   DML_lex_coords(coords, latdim, latsize, (DML_SiteRank)index);
 }
 
 int QIO_scalar_num_sites(int node){
+  _QIO_UNUSED_PARAM(node);
   return QIO_mpp_layout.volume;
 }
 
@@ -436,6 +439,7 @@ int QIO_scalar_to_ionode_index(int scalar_node, int scalar_index){
    with sites in lexicographic order */
 /* We really don't need the fs parameter */
 QIO_Layout *QIO_create_scalar_layout(QIO_Layout *layout, QIO_Filesystem *fs){
+  _QIO_UNUSED_PARAM(fs);
   QIO_Layout *scalar_layout;
   char myname[] = "QIO_create_scalar_layout";
 

--- a/lib/qio/QIO_info_private.c
+++ b/lib/qio/QIO_info_private.c
@@ -705,8 +705,8 @@ int QIO_get_spins(QIO_RecordInfo *record_info){
   return record_info->spins.value;
 }
 
-int QIO_get_typesize(QIO_RecordInfo *record_info){
-  return record_info->typesize.value;
+size_t QIO_get_typesize(QIO_RecordInfo *record_info){
+  return (size_t)(record_info->typesize.value);
 }
 
 int QIO_get_datacount(QIO_RecordInfo *record_info){
@@ -968,7 +968,7 @@ int QIO_compare_record_info(QIO_RecordInfo *found, QIO_RecordInfo *expect){
     if(!QIO_defined_typesize(found) &&
        QIO_get_typesize(found) != QIO_get_typesize(expect))
       {
-	printf("%s:Typesize mismatch expected %d found %d \n",myname,
+	printf("%s:Typesize mismatch expected %lu found %lu \n",myname,
 	       QIO_get_typesize(expect),QIO_get_typesize(found));
 	return QIO_ERR_REC_INFO;
       }

--- a/lib/qio/QIO_open_read.c
+++ b/lib/qio/QIO_open_read.c
@@ -581,6 +581,7 @@ int
 QIO_open_read_nonmaster(QIO_Reader *qio_in, const char *filename,
 			QIO_Iflag *iflag)
 {
+  _QIO_UNUSED_PARAM(iflag);
   DML_Layout *dml_layout = qio_in->layout;
   int this_node = dml_layout->this_node;
   LRL_FileReader *lrl_file_in = NULL;

--- a/lib/qio/QIO_read_record_data.c
+++ b/lib/qio/QIO_read_record_data.c
@@ -86,7 +86,7 @@ int QIO_generic_read_record_data(QIO_Reader *in,
   count = QIO_get_datacount(record_info);
   if(datum_size !=  QIO_get_typesize(record_info) * count)
     {
-      printf("%s(%d): requested byte count %lu disagrees with the record %d * %d\n",
+      printf("%s(%d): requested byte count %lu disagrees with the record %lu * %d\n",
 	     myname,this_node,(unsigned long)datum_size,
 	     QIO_get_typesize(record_info), count);
       

--- a/lib/qio/QIO_string.c
+++ b/lib/qio/QIO_string.c
@@ -134,9 +134,9 @@ void QIO_string_copy(QIO_String *dest, QIO_String *src)
 }
 
 /* Non-destructive string reallocation */
-void QIO_string_realloc(QIO_String *qs, int length)
+void QIO_string_realloc(QIO_String *qs, size_t length)
 {
-  int i,min;
+  size_t i,min;
   char *tmp;
 
   /* If NULL string is passed just return */
@@ -153,7 +153,7 @@ void QIO_string_realloc(QIO_String *qs, int length)
   if(tmp == NULL) {
     /* Returning here is a bad idea as the string is not really
        realloced */
-    printf("QIO_string_realloc: Can't malloc size %d\n",length);
+    printf("QIO_string_realloc: Can't malloc size %lu\n",length);
     fflush(stdout);
     exit(-1);
     /* return */
@@ -175,7 +175,7 @@ void QIO_string_realloc(QIO_String *qs, int length)
 }
 
 void QIO_string_append(QIO_String *qs, const char *const string){
-  int len, totlen;
+  size_t len, totlen;
 
   if(qs == NULL || string == NULL)return;
   len = strlen(string);

--- a/lib/qio/QIO_utils.c
+++ b/lib/qio/QIO_utils.c
@@ -52,11 +52,20 @@ int QIO_verbosity(){
 char *QIO_filename_edit(const char *filename, int volfmt, int this_node){
 
   /* Caller must clean up returned filename */
-  int n = strlen(filename) + 12;
-  char *newfilename = (char *)malloc(n);
+  char *newfilename = NULL;
   const char *dirname_end;
   int dirname_len;
-
+ 
+  size_t old_n = strlen(filename);
+  if( old_n+12 > QIO_MAX_FILENAME_LENGTH ) {
+    printf("QIO_filename_edit: input filename has size %lu.  Output filename would be greater "
+	 "than QIO_MAX_FILENAME_LENGHT( %lu ). Failing!\n", 
+		    old_n + 12, (size_t)QIO_MAX_FILENAME_LENGTH);
+    return NULL;
+  }
+	
+  size_t n = (old_n + 12);
+  newfilename = (char *)malloc(n);
   if(!newfilename){
     printf("QIO_filename_edit: Can't malloc newfilename\n");
     return NULL;
@@ -64,8 +73,11 @@ char *QIO_filename_edit(const char *filename, int volfmt, int this_node){
 
   /* No change for singlefile format */
   if(volfmt == QIO_SINGLEFILE){
-    strncpy(newfilename,filename,strlen(filename));
-    newfilename[strlen(filename)] = '\0';
+    /* We now that newfilename is longer than filename so 
+     * and that the old filename is null terminated within QIO_MAX_FILENAME_LENTGH
+     * so strcpy is safe */ 
+    strcpy(newfilename,filename);
+    newfilename[old_n] = '\0';
   }
   /* Add volume suffix for multifile and partfile formats */
   else if (volfmt == QIO_PARTFILE_DIR) {

--- a/lib/qio/QIO_write.c
+++ b/lib/qio/QIO_write.c
@@ -35,7 +35,7 @@ int QIO_write_record_info(QIO_Writer *out, QIO_RecordInfo *record_info,
               size_t datum_size, int word_size,
 	      QIO_String *xml_record, 
 	      int *msg_begin, int *msg_end){
-
+  _QIO_UNUSED_PARAM(word_size);
   QIO_String *xml_record_private;
   QIO_String *xml_ildg_format;
   QIO_ILDGFormatInfo *ildg_info;
@@ -50,7 +50,7 @@ int QIO_write_record_info(QIO_Writer *out, QIO_RecordInfo *record_info,
      private record metadata and the byte count per site to be written */
   if(datum_size != QIO_get_typesize(record_info) * count)
     {
-      printf("%s(%d): bytes per site mismatch %lu != %d * %d\n",
+      printf("%s(%d): bytes per site mismatch %lu != %lu * %d\n",
 	     myname,this_node,(unsigned long)datum_size,
 	     QIO_get_typesize(record_info),
 	     QIO_get_datacount(record_info));


### PR DESCRIPTION
This set of fixesd eliminates a bunch of warnings:

*  _QIO_UNUSED_PARAM() macro in many places eliminates Unused arg warnings
*  a couple of size_t comparisons eliminate warnings of signed/unsigned comparisons
* using sprintfs and strcpy in place of strncpy and strncat  eliminate warnings about truncation and overflow based on computed bound warnings. The fact is that we compute bounds with strlen() and so if we have a bad input with no NULLs we are in a bad place. already. So as long as strlen() on the input succeed the non checking variants ought to be safe.

